### PR TITLE
Keep original part description

### DIFF
--- a/GameData/RealPlume/000_Generic_Plumes/000_zRealPlume.cfg
+++ b/GameData/RealPlume/000_Generic_Plumes/000_zRealPlume.cfg
@@ -1,6 +1,5 @@
 @PART[*]:HAS[@PLUME[*]]:FOR[zRealPlume]:NEEDS[SmokeScreen]
 {
-    @description ^= :$: Plume configured by RealPlume.:
     //Check for all parameters, add a default if parameter is missing.
     @PLUME,*
     {


### PR DESCRIPTION
The hard-coded mention is distracting, especially in localized versions of the game.